### PR TITLE
Added support for usage logging

### DIFF
--- a/includes/aw2_library.php
+++ b/includes/aw2_library.php
@@ -4560,7 +4560,11 @@ static function module_run($collection,$module,$template=null,$content=null,$att
 	}
 	
 	$stack_id=self::module_push($arr);
-
+	
+	if(defined('AWESOME_LOG_USAGE') && AWESOME_LOG_USAGE == "yes"){
+		require_once('usage_log.php');
+		$log = aw2_usage_log::log_usage($collection, $module);
+	}
 	
 	if(!$template){
 		if($content){

--- a/includes/usage_log.php
+++ b/includes/usage_log.php
@@ -1,0 +1,42 @@
+<?php 
+
+class aw2_usage_log{
+	
+	static function log_usage($collection=null,$module=null){
+		$service = 0;
+		if(isset($collection['service']) && $collection['service'] == "yes")
+			$service = 1;
+
+		$post_type = '';
+		if(isset($collection['post_type']))
+			$post_type = $collection['post_type'];
+
+		if(!defined('AWESOME_LOG_DB'))
+			define('AWESOME_LOG_DB', DB_NAME);
+
+		$nmysqli = new SimpleMySQLi(DB_HOST, DB_USER, DB_PASSWORD, DB_NAME, "utf8mb4", "assoc");
+		$nmysqli->query("SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci");
+
+		$sql = "
+		start TRANSACTION;
+		set @post_type='".$post_type."';
+		set @module='".$module."';
+		set @service='".$service."';
+		
+		SELECT @id:=ID FROM ".AWESOME_LOG_DB.".usage_log WHERE post_type=@post_type and module_slug=@module;
+
+		IF @id is null THEN
+
+			INSERT INTO ".AWESOME_LOG_DB.".`usage_log` (`post_type`,`module_slug`,`service`) VALUES ( '".$post_type."','".$module."','".$service."');
+		ELSE
+			UPDATE ".AWESOME_LOG_DB.".`usage_log` SET count=count+1
+			WHERE ID = @id;
+		END IF;
+			
+		COMMIT;
+		";
+				
+		$obj = $nmysqli->multi_query($sql);
+		$nmysqli->close();
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,10 @@ https://getawesomestudio.com/
 
 == Changelog ==
 
+
+= 1.3.4 =
+* Added support for logging usage of all post types and modules. This feature is disabled by default and can be enabled by adding AWESOME_LOG_DEBUG = yes in the wp_config of the specific site.
+
 = 1.3.3 =
 * Fixed the issue of % sign getting converted in to hex placeholder string.
 * Ability to update a .docx file template


### PR DESCRIPTION
Added support for logging usage of all post types and modules. 

This feature is disabled by default and can be enabled by adding AWESOME_LOG_DEBUG = yes in the wp_config of the specific site.