### PR TITLE
Updated money_format to NumberFormatter for PHP8

### DIFF
--- a/core-handlers/lang/m.php
+++ b/core-handlers/lang/m.php
@@ -245,8 +245,8 @@ function _money_format($value, $atts){
 	if($format=="yes"){
 		$format = 'en_IN';
 	}
-	setlocale(LC_MONETARY, $format);
-    $value = money_format('%!i', (float)$value);
+	$fmt = new \NumberFormatter( $format, \NumberFormatter::CURRENCY );
+	$value = $fmt->formatCurrency($value, "INR");
 	$value =str_replace('.00','',$value);
 	return $value;
 }


### PR DESCRIPTION
PHP Extension intl needs to be enabled in order to access the NumberFormatter class